### PR TITLE
Resize command

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -52,6 +52,11 @@ var (
 		Aliases: []string{"v"},
 		Usage:   "Show additional details of darknodes",
 	}
+	StorageFlag = &cli.StringFlag{
+		Name:    "size",
+		Aliases: []string{"s"},
+		Usage:   "Resize darknode storage",
+	}
 )
 
 // AWS flags

--- a/nodectl.go
+++ b/nodectl.go
@@ -174,6 +174,14 @@ func App() *cli.App {
 				return fmt.Errorf("cannot fetch darknode address")
 			},
 		},
+		{
+			Name:  "resize",
+			Usage: "Update your Darknode to the latest version",
+			Flags: []cli.Flag{TagsFlag, StorageFlag},
+			Action: func(c *cli.Context) error {
+				return ResizeDarknode(c)
+			},
+		},
 	}
 
 	// Show error message and display the help page when command is not found.


### PR DESCRIPTION
The `resize` command allows specifying new storage size for a deployed darknode instance

[x] Edit terraform config file for supported providers (aws, digitalocean) and apply changes
[ ] Create backup file and overwrite the config file if changes fail